### PR TITLE
bugfix: fix deploy.yaml workflow error

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,8 +1,5 @@
 name: Deploy to Moxie Server
 on:
-    push:
-        branches:
-            - bugfix/moxie-host-error
     workflow_dispatch:
         inputs:
             version:
@@ -32,3 +29,4 @@ jobs:
                       VERSION=${{ env.VERSION }} docker-compose pull
                       docker-compose down
                       VERSION=${{ env.VERSION }} docker-compose up -d
+                      docker-compose ps


### PR DESCRIPTION
## Description
Fixes the deploy workflow by removing the flaky `scp-action` step and replacing it with a `curl` directly on the server. Also fixes explicit `docker pull` commands by letting `docker-compose pull` handle versioning via the compose file.

Closes # (issue if applicable)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Other: