### PR TITLE
ci: add auth microservice in github workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,6 +18,10 @@ backend-notification:
   - changed-files:
       - any-glob-to-any-file: "backend/notification/**"
 
+backend-auth:
+  - changed-files:
+      - any-glob-to-any-file: "backend/auth/**"
+
 ci:
   - changed-files:
       - any-glob-to-any-file: ".github/**"

--- a/.github/workflows/promote-latest.yaml
+++ b/.github/workflows/promote-latest.yaml
@@ -31,7 +31,7 @@ jobs:
                   BASE=${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
                   VERSION=${{ inputs.version }}
 
-                  for service in frontend backend-worklog backend-notification backend-task; do
+                  for service in frontend backend-worklog backend-notification backend-task backend-auth; do
                     docker pull $BASE/$service:$VERSION
                     docker tag  $BASE/$service:$VERSION $BASE/$service:latest
                     docker push $BASE/$service:latest

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -42,3 +42,13 @@ jobs:
               with:
                   context: ./backend/task
                   push: false
+
+    build_backend_auth:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - name: Build Backend Docker Image
+              uses: docker/build-push-action@v5
+              with:
+                  context: ./backend/auth
+                  push: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,9 +112,34 @@ jobs:
                   tags: |
                     ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}/backend-task:${{ env.VERSION }}
 
+    build_backend_auth:
+        name: build_backend_auth
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            - uses: actions/checkout@v6
+            - name: Log in to GHCR
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Set lowercase image name
+              id: image
+              run: echo "name=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]' | sed 's/\/-oz-/\/oz-/')" >> $GITHUB_OUTPUT
+            - name: Build and push Backend
+              uses: docker/build-push-action@v5
+              with:
+                  context: ./backend/auth
+                  push: true
+                  tags: |
+                    ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}/backend-auth:${{ env.VERSION }}
+
     create_release:
         name: create_release
-        needs: [build_frontend, build_backend_worklog, build_backend_notification, build_backend_task]
+        needs: [build_frontend, build_backend_worklog, build_backend_notification, build_backend_task, build_backend_auth]
         runs-on: ubuntu-latest
         permissions:
             contents: write


### PR DESCRIPTION
## Description
The feat/add-auth-release branch adds the backend/auth microservice to all GitHub Actions workflows. Previously, the auth service existed in the codebase and docker-compose but was missing from CI/CD pipelines (pull-request checks, release builds, promote-latest, and PR labeling). This PR fills that gap.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Other: Github actions update