### PR TITLE
feat: update date fields to include time

### DIFF
--- a/backend/auth/src/main/java/auth/user/AuthRepository.java
+++ b/backend/auth/src/main/java/auth/user/AuthRepository.java
@@ -33,7 +33,7 @@ public class AuthRepository{
             .append("email", email)
             .append("name", name)
             .append("role", role)
-            .append("createdAt", Instant.now().toString());
+            .append("createdAt", Instant.now());
         collection.insertOne(newUser);
         return newUser;
     }

--- a/backend/worklog/src/main/java/worklog/application/WorklogEntry.java
+++ b/backend/worklog/src/main/java/worklog/application/WorklogEntry.java
@@ -1,6 +1,6 @@
 package worklog.application;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import jakarta.validation.Valid;
@@ -18,9 +18,10 @@ public class WorklogEntry {
     private String worklogName;
 
     @NotNull(message = "Date created required")
-    private LocalDate dateCreated;
+    private LocalDateTime dateCreated;
 
-    private LocalDate dateSubmitted;
+    @NotNull(message = "Date submitted required")
+    private LocalDateTime dateSubmitted;
     private boolean reviewed = false;
 
     @Valid
@@ -46,19 +47,19 @@ public class WorklogEntry {
         return authorName;
     }
 
-    public void setDateCreated(LocalDate dateCreated) {
+    public void setDateCreated(LocalDateTime dateCreated) {
         this.dateCreated = dateCreated;
     }
 
-    public LocalDate getDateCreated() {
+    public LocalDateTime getDateCreated() {
         return dateCreated;
     }
 
-    public void setDateSubmitted(LocalDate dateSubmitted) {
+    public void setDateSubmitted(LocalDateTime dateSubmitted) {
         this.dateSubmitted = dateSubmitted;
     }
 
-    public LocalDate getDateSubmitted() {
+    public LocalDateTime getDateSubmitted() {
         return dateSubmitted;
     }
 

--- a/backend/worklog/src/main/java/worklog/application/WorklogRepository.java
+++ b/backend/worklog/src/main/java/worklog/application/WorklogRepository.java
@@ -1,8 +1,9 @@
 package worklog.application;
 
 import java.io.StringWriter;
-import java.time.format.DateTimeFormatter;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -33,7 +34,6 @@ import jakarta.validation.Validator;
 import jakarta.ws.rs.core.Response;
 import worklog.application.classes.Task;
 
-
 @ApplicationScoped // Add this so CDI can manage this class
 public class WorklogRepository {
 
@@ -42,18 +42,15 @@ public class WorklogRepository {
     @Inject
     Validator validator;
 
-    DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     Bson excludeDraft = Filters.or(
-        Filters.exists("isDraft", false),  
-        Filters.eq("isDraft", false)         
-    );
+            Filters.exists("isDraft", false),
+            Filters.eq("isDraft", false));
 
     @Inject
     public void setCollection(MongoDatabase db) {
         CodecRegistry pojoCodecRegistry = fromRegistries(
-            MongoClientSettings.getDefaultCodecRegistry(),
-            fromProviders(PojoCodecProvider.builder().automatic(true).build())
-        );
+                MongoClientSettings.getDefaultCodecRegistry(),
+                fromProviders(PojoCodecProvider.builder().automatic(true).build()));
 
         // Apply the registry to the database provided by the producer
         MongoDatabase codecDb = db.withCodecRegistry(pojoCodecRegistry);
@@ -71,15 +68,13 @@ public class WorklogRepository {
         collection.deleteMany(Filters.and(
                 Filters.eq("authorName", entry.getAuthorName()),
                 Filters.eq("worklogName", entry.getWorklogName()),
-                Filters.eq("isDraft", true)
-        ));
+                Filters.eq("isDraft", true)));
 
         Document newDoc = new Document();
 
         newDoc.put("authorName", entry.getAuthorName());
-        newDoc.put("worklogName", entry.getWorklogName());
-        newDoc.put("dateCreated", entry.getDateCreated().format(dateTimeFormatter));
-        newDoc.put("dateSubmitted", entry.getDateSubmitted().format(dateTimeFormatter));
+        newDoc.put("dateCreated", Date.from(entry.getDateCreated().toInstant(ZoneOffset.UTC)));
+        newDoc.put("dateSubmitted", Date.from(entry.getDateSubmitted().toInstant(ZoneOffset.UTC)));
         newDoc.put("collaborators", entry.getCollaborators());
         newDoc.put("worklogName", entry.getWorklogName());
         newDoc.put("taskList", formatTask(entry.getTaskList()));
@@ -95,73 +90,72 @@ public class WorklogRepository {
 
         Document newDoc = new Document();
 
-        
         Optional.ofNullable(entry.getDateCreated())
-        .ifPresent(v -> newDoc.put("dateCreated", v.format(dateTimeFormatter)));
-        
-        Optional.ofNullable(entry.getDateSubmitted())
-        .ifPresent(v -> newDoc.put("dateSubmitted", v.format(dateTimeFormatter)));
-        
-        Optional.ofNullable(entry.getCollaborators())
-        .ifPresent(v -> newDoc.put("collaborators", v));
-        
-        Optional.ofNullable(entry.getTaskList())
-        .ifPresent(v -> newDoc.put("taskList", formatTask(v)));
-        
-        
+                .ifPresent(v -> newDoc.put("dateCreated", Date.from(v.toInstant(ZoneOffset.UTC))));
 
-        
+        Optional.ofNullable(entry.getDateSubmitted())
+                .ifPresent(v -> newDoc.put("dateSubmitted", Date.from(v.toInstant(ZoneOffset.UTC))));
+
+        Optional.ofNullable(entry.getCollaborators())
+                .ifPresent(v -> newDoc.put("collaborators", v));
+
+        Optional.ofNullable(entry.getTaskList())
+                .ifPresent(v -> newDoc.put("taskList", formatTask(v)));
+
         newDoc.put("authorName", entry.getAuthorName());
         newDoc.put("worklogName", entry.getWorklogName());
         newDoc.put("isDraft", true);
         newDoc.put("reviewed", false);
 
         collection.findOneAndReplace(Filters.and(
-            Filters.eq("authorName", entry.getAuthorName()),
-            Filters.eq("worklogName", entry.getWorklogName()),
-            Filters.eq("isDraft", true)
+                Filters.eq("authorName", entry.getAuthorName()),
+                Filters.eq("worklogName", entry.getWorklogName()),
+                Filters.eq("isDraft", true)
 
         ), newDoc, new FindOneAndReplaceOptions().upsert(true));
 
         return Response.status(Response.Status.OK).entity(newDoc.toJson()).build();
     }
 
-	public Response getAll() {
-		return responseByQuery(excludeDraft);
-	}
+    public Response getAll() {
+        return responseByQuery(excludeDraft);
+    }
 
-    //TODO ADD FILTER FOR CURRENT USER
+    // TODO ADD FILTER FOR CURRENT USER
     public Response getDraft() {
-		return responseByQuery(Filters.eq("isDraft", true));
-	}
+        return responseByQuery(Filters.eq("isDraft", true));
+    }
 
-    //New functionality for findByAuthor: if an instructor is the one seeing it, then update the "reviewed" field.
-	public Response findByAuthor(String authorName) {
+    // New functionality for findByAuthor: if an instructor is the one seeing it,
+    // then update the "reviewed" field.
+    public Response findByAuthor(String authorName) {
         return responseByQuery(Filters.and(Filters.eq("authorName", authorName), excludeDraft));
-	}
+    }
 
     public Response deleteAll() {
         collection.drop();
         return Response.status(Response.Status.OK).entity("[\"Dropped collection\"]").build();
     }
 
-
-
-
-    //input null for getAll
+    // input null for getAll
     private Response responseByQuery(Bson query) {
         StringWriter sb = new StringWriter();
         try {
             sb.append("[");
             FindIterable<Document> docs;
 
-            if (query != null) {docs = collection.find(query);}
-		    else {docs = collection.find();}
+            if (query != null) {
+                docs = collection.find(query);
+            } else {
+                docs = collection.find();
+            }
 
             boolean first = true;
             for (Document d : docs) {
-                if (!first) sb.append(",");
-                else first = false;
+                if (!first)
+                    sb.append(",");
+                else
+                    first = false;
                 sb.append(d.toJson());
             }
             sb.append("]");
@@ -171,7 +165,6 @@ public class WorklogRepository {
         return Response.status(Response.Status.OK).entity(sb.toString()).build();
     }
 
-
     private List<Document> formatTask(List<Task> taskList) {
         List<Document> taskDocs = new ArrayList<>();
 
@@ -179,29 +172,28 @@ public class WorklogRepository {
             Document newDoc = new Document();
 
             Optional.ofNullable(task.getTaskName())
-                .ifPresent(v -> newDoc.put("taskName", v));
+                    .ifPresent(v -> newDoc.put("taskName", v));
 
             Optional.ofNullable(task.getGoal())
-                .ifPresent(v -> newDoc.put("goal", v));
+                    .ifPresent(v -> newDoc.put("goal", v));
 
             Optional.ofNullable(task.getAssignedUser())
-                .ifPresent(v -> newDoc.put("assignedUser", v));
+                    .ifPresent(v -> newDoc.put("assignedUser", v));
 
             Optional.ofNullable(task.getDueDate())
-                .ifPresent(v -> newDoc.put("dueDate", v.format(dateTimeFormatter)));
-                
+                    .ifPresent(v -> newDoc.put("dueDate", Date.from(v.toInstant(ZoneOffset.UTC))));
+
             Optional.ofNullable(task.getCreationDate())
-                .ifPresent(v -> newDoc.put("creationDate", v.format(dateTimeFormatter)));
+                    .ifPresent(v -> newDoc.put("creationDate", Date.from(v.toInstant(ZoneOffset.UTC))));
 
             Optional.ofNullable(task.getCollaborators())
-                .ifPresent(v -> newDoc.put("collaborators", v));
-            
+                    .ifPresent(v -> newDoc.put("collaborators", v));
+
             Optional.ofNullable(task.getStatus())
-                .ifPresent(v -> newDoc.put("status", v));
+                    .ifPresent(v -> newDoc.put("status", v));
 
             Optional.ofNullable(task.getReflection())
-                .ifPresent(v -> newDoc.put("reflection", v));
-
+                    .ifPresent(v -> newDoc.put("reflection", v));
 
             taskDocs.add(newDoc);
         }
@@ -209,40 +201,40 @@ public class WorklogRepository {
         return taskDocs;
     }
 
-    //Need to make other functions to update specific fields like title, duedate, etc.
-    //Right now this replaces the entire entry.
-    // (Xander): ^May not be needed, worklog aspects dont really have to be updated once they're in the db.... question for requirments?
+    // Need to make other functions to update specific fields like title, duedate,
+    // etc.
+    // Right now this replaces the entire entry.
+    // (Xander): ^May not be needed, worklog aspects dont really have to be updated
+    // once they're in the db.... question for requirments?
     public Response updateWorklog(String id, WorklogEntry updatedEntry, boolean isInstructor) {
         Document newDoc = new Document();
 
         newDoc.put("authorName", updatedEntry.getAuthorName());
-        newDoc.put("dateCreated", updatedEntry.getDateCreated().format(dateTimeFormatter));
-        newDoc.put("dateSubmitted", updatedEntry.getDateSubmitted().format(dateTimeFormatter));
+        newDoc.put("dateCreated", Date.from(updatedEntry.getDateCreated().toInstant(ZoneOffset.UTC)));
+        newDoc.put("dateSubmitted", Date.from(updatedEntry.getDateSubmitted().toInstant(ZoneOffset.UTC)));
         newDoc.put("collaborators", updatedEntry.getCollaborators());
         newDoc.put("taskList", formatTask(updatedEntry.getTaskList()));
         newDoc.put("worklogName", updatedEntry.getWorklogName());
-        
+
         if (isInstructor) {
             newDoc.put("reviewed", updatedEntry.isReviewed());
-        }
-        else {
+        } else {
             newDoc.put("reviewed", false);
         }
-        
 
         ObjectId oid; // ID of mongo collection entry
         try {
             oid = new ObjectId(id);
         } catch (Exception e) {
             return Response
-                .status(Response.Status.BAD_REQUEST)
-                .entity("[\"Invalid object id!\"]")
-                .build();
+                    .status(Response.Status.BAD_REQUEST)
+                    .entity("[\"Invalid object id!\"]")
+                    .build();
         }
 
         collection.replaceOne(eq("_id", oid), newDoc);
         return Response.ok(updatedEntry).build();
-        
+
     }
 
     public Response deleteWorklog(String id) {
@@ -252,9 +244,9 @@ public class WorklogRepository {
             oid = new ObjectId(id);
         } catch (Exception e) {
             return Response
-                .status(Response.Status.BAD_REQUEST)
-                .entity("[\"Invalid object id!\"]")
-                .build();
+                    .status(Response.Status.BAD_REQUEST)
+                    .entity("[\"Invalid object id!\"]")
+                    .build();
         }
 
         collection.deleteOne(eq("_id", oid));
@@ -269,6 +261,5 @@ public class WorklogRepository {
         }
         return messages.build();
     }
-    
-    
+
 }

--- a/backend/worklog/src/main/java/worklog/application/WorklogRepository.java
+++ b/backend/worklog/src/main/java/worklog/application/WorklogRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.bson.Document;
+import org.bson.json.JsonWriterSettings;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
@@ -137,6 +138,12 @@ public class WorklogRepository {
         return Response.status(Response.Status.OK).entity("[\"Dropped collection\"]").build();
     }
 
+    private static final JsonWriterSettings JSON_SETTINGS = JsonWriterSettings.builder()
+            .dateTimeConverter((value, writer) -> writer.writeString(
+                    new java.util.Date(value).toInstant().toString()))
+            .objectIdConverter((value, writer) -> writer.writeString(value.toHexString()))
+            .build();
+
     // input null for getAll
     private Response responseByQuery(Bson query) {
         StringWriter sb = new StringWriter();
@@ -156,7 +163,7 @@ public class WorklogRepository {
                     sb.append(",");
                 else
                     first = false;
-                sb.append(d.toJson());
+                sb.append(d.toJson(JSON_SETTINGS));
             }
             sb.append("]");
         } catch (Exception e) {

--- a/backend/worklog/src/main/java/worklog/application/WorklogService.java
+++ b/backend/worklog/src/main/java/worklog/application/WorklogService.java
@@ -1,6 +1,5 @@
 package worklog.application;
 
-import java.time.LocalDate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -76,15 +75,8 @@ public class WorklogService {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Uploads new worklog to db")
     public Response createWorklog(@Valid WorklogEntry entry) {
-
-        // Automatically set dateCreated if not provided
-        if (entry.getDateCreated() == null) {
-            entry.setDateCreated(LocalDate.now());
-        }
-
         logger.log(Level.INFO, "POST: createWorklog()");
         return repo.addWorklog(entry);
-
     }
 
 

--- a/backend/worklog/src/main/java/worklog/application/classes/Task.java
+++ b/backend/worklog/src/main/java/worklog/application/classes/Task.java
@@ -1,6 +1,6 @@
 package worklog.application.classes;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 public class Task {
@@ -11,9 +11,9 @@ public class Task {
 
     private String assignedUser; //Student or teacher object at some point? 
     
-    private LocalDate dueDate;
+    private LocalDateTime dueDate;
 
-    private LocalDate creationDate;
+    private LocalDateTime creationDate;
     private String status;
 
     private ArrayList<String> collaborators;
@@ -54,25 +54,25 @@ public class Task {
 
 
 
-    public LocalDate getDueDate() {
+    public LocalDateTime getDueDate() {
         return this.dueDate;
     }
 
 
 
-    public void setDueDate(LocalDate dueDate) {
+    public void setDueDate(LocalDateTime dueDate) {
         this.dueDate = dueDate;
     }
 
 
 
-    public LocalDate getCreationDate() {
+    public LocalDateTime getCreationDate() {
         return this.creationDate;
     }
 
 
 
-    public void setCreationDate(LocalDate creationDate) {
+    public void setCreationDate(LocalDateTime creationDate) {
         this.creationDate = creationDate;
     }
 

--- a/frontend/app/(root)/(home)/instructor/page.tsx
+++ b/frontend/app/(root)/(home)/instructor/page.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import getWorklogDate from "@/components/custom/utils/func/getDate";
+import { fmtDate, fmtDateTime } from "@/components/custom/utils/func/formatDate";
 import {
   Collapsible,
   CollapsibleContent,
@@ -43,13 +44,18 @@ function ReviewButton({ log }: { log: any }) {
   const mutation = useMutation({
     mutationFn: () => {
       const id = typeof log._id === "object" ? log._id.$oid : log._id;
+      const stripZ = (v: string) => (v ? v.replace("Z", "") : v);
       const body = {
         authorName: log.authorName,
         worklogName: log.worklogName,
-        dateCreated: log.dateCreated,
-        dateSubmitted: log.dateSubmitted,
+        dateCreated: stripZ(log.dateCreated),
+        dateSubmitted: stripZ(log.dateSubmitted),
         collaborators: log.collaborators ?? [],
-        taskList: log.taskList ?? [],
+        taskList: (log.taskList ?? []).map((t: any) => ({
+          ...t,
+          dueDate: t.dueDate ? stripZ(t.dueDate) : t.dueDate,
+          creationDate: t.creationDate ? stripZ(t.creationDate) : t.creationDate,
+        })),
         reviewed: !log.reviewed,
       };
       return updateWorklog(id, body);
@@ -151,7 +157,7 @@ function StudentRow({ student }: { student: { email: string; name: string; log: 
                 <div key={li} className="space-y-2 border rounded-lg p-3 bg-white">
                   <div className="flex items-center justify-between">
                     <p className="text-xs font-medium text-muted-foreground">
-                      Submission {student.logs.length - li} · Submitted {log.dateSubmitted} · {log.taskList?.length ?? 0} task(s)
+                      Submission {student.logs.length - li} · Submitted {fmtDateTime(log.dateSubmitted)} · {log.taskList?.length ?? 0} task(s)
                     </p>
                     <ReviewButton log={log} />
                   </div>
@@ -178,7 +184,7 @@ function StudentRow({ student }: { student: { email: string; name: string; log: 
                         {task.dueDate && (
                           <span className="flex items-center gap-1">
                             <CalendarDays className="h-3 w-3" />
-                            {task.dueDate}
+                            {fmtDate(task.dueDate)}
                           </span>
                         )}
                         {task.collaborators?.filter((c: string) => c).length > 0 && (
@@ -284,7 +290,7 @@ const InstructorDashboard = () => {
     let lateDays = 0;
 
     if (latestLog) {
-      const submitted = new Date(latestLog.dateSubmitted + "T00:00:00");
+      const submitted = new Date(latestLog.dateSubmitted);
       const diff = Math.floor(
         (submitted.getTime() - dueDate.getTime()) / (1000 * 60 * 60 * 24),
       );

--- a/frontend/app/(root)/(home)/notification/page.tsx
+++ b/frontend/app/(root)/(home)/notification/page.tsx
@@ -5,6 +5,7 @@ import { getWorkLog } from "@/components/custom/utils/api_utils/worklogs/allReq"
 import { useAtomValue } from "jotai";
 import { userAtom } from "@/components/custom/utils/context/state";
 import getWorklogDate from "@/components/custom/utils/func/getDate";
+import { fmtDateTime } from "@/components/custom/utils/func/formatDate";
 import { Card, CardContent, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
@@ -22,7 +23,7 @@ function getLateDays(log: any): number {
   const dueDate = new Date(semesterStart);
   dueDate.setDate(dueDate.getDate() + week * 7);
   dueDate.setHours(23, 59, 0, 0);
-  const submitted = new Date(log.dateSubmitted + "T00:00:00");
+  const submitted = new Date(log.dateSubmitted);
   const diffDays = Math.floor(
     (submitted.getTime() - dueDate.getTime()) / (1000 * 60 * 60 * 24),
   );
@@ -164,7 +165,7 @@ export default function NotificationPage() {
                             )}
                           </div>
                           <p className="text-xs text-muted-foreground">
-                            Submitted {log.dateSubmitted} — {log.taskList?.length ?? 0} task(s)
+                            Submitted {fmtDateTime(log.dateSubmitted)} — {log.taskList?.length ?? 0} task(s)
                           </p>
                         </div>
                       </div>

--- a/frontend/app/(root)/(home)/worklogs/review/page.tsx
+++ b/frontend/app/(root)/(home)/worklogs/review/page.tsx
@@ -12,6 +12,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { ArrowLeft, CalendarDays, Clock, ChevronDown, ChevronRight } from "lucide-react";
+import { fmtDate, fmtDateTime } from "@/components/custom/utils/func/formatDate";
 import { Suspense, useEffect, useState } from "react";
 
 const statusLabel: Record<string, string> = {
@@ -40,11 +41,7 @@ function SubmissionCollapsible({
               <h2 className="text-base font-semibold">Submission {subNum}</h2>
               <span className="text-xs text-muted-foreground flex items-center gap-1">
                 <Clock className="h-3 w-3" />
-                {new Date(submission.dateSubmitted + "T00:00:00").toLocaleDateString("en-US", {
-                  month: "short",
-                  day: "numeric",
-                  year: "numeric",
-                })}
+                {fmtDateTime(submission.dateSubmitted)}
               </span>
             </div>
             {open ? (
@@ -88,7 +85,7 @@ function SubmissionCollapsible({
                       <p className="text-xs font-medium text-muted-foreground mb-1">Deadline</p>
                       <p className="text-sm flex items-center gap-1.5">
                         <CalendarDays className="h-3.5 w-3.5 text-muted-foreground" />
-                        {task.dueDate}
+                        {fmtDate(task.dueDate)}
                       </p>
                     </div>
                     <div>

--- a/frontend/components/custom/screen/home/NotifCenter.tsx
+++ b/frontend/components/custom/screen/home/NotifCenter.tsx
@@ -16,6 +16,7 @@ import Link from "next/link";
 
 import { userAtom } from "@/components/custom/utils/context/state";
 import getWorklogDate from "../../utils/func/getDate";
+import { fmtDateTime } from "../../utils/func/formatDate";
 import { CheckCircle2, FileText, ArrowRight, Clock, AlertTriangle } from "lucide-react";
 
 function getLateDays(log: any): number {
@@ -25,7 +26,7 @@ function getLateDays(log: any): number {
   const dueDate = new Date(semesterStart);
   dueDate.setDate(dueDate.getDate() + week * 7);
   dueDate.setHours(23, 59, 0, 0);
-  const submitted = new Date(log.dateSubmitted + "T00:00:00");
+  const submitted = new Date(log.dateSubmitted);
   const diffDays = Math.floor(
     (submitted.getTime() - dueDate.getTime()) / (1000 * 60 * 60 * 24),
   );
@@ -110,7 +111,7 @@ function RecentLogsSection({ worklogs }: { worklogs: any[] }) {
                         )}
                       </div>
                       <p className="text-xs text-muted-foreground truncate">
-                        Submitted {log.dateSubmitted} —{" "}
+                        Submitted {fmtDateTime(log.dateSubmitted)} —{" "}
                         {log.taskList?.length ?? 0} task(s)
                       </p>
                     </div>

--- a/frontend/components/custom/screen/notification/Notification.tsx
+++ b/frontend/components/custom/screen/notification/Notification.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { userAtom } from "@/components/custom/utils/context/state";
 import { worklogEditAtom } from "@/components/custom/utils/context/state"; // adjust path
 import getWorklogDate from "../../utils/func/getDate";
+import { fmtDate } from "../../utils/func/formatDate";
 import { useRouter } from "next/navigation";
 import {
   CheckCircle2,
@@ -18,6 +19,7 @@ import {
   Hourglass,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useEffect } from "react";
 
 type WorklogStatus = "submitted" | "late" | "missing" | "current" | "upcoming";
 
@@ -144,11 +146,7 @@ function buildWeekEntries(worklogs: any[]): WeekEntry[] {
         week: w,
         dueDate: dueDateStr,
         submittedDate: log
-          ? new Date(log.dateSubmitted + "T00:00:00").toLocaleDateString("en-US", {
-              month: "short",
-              day: "numeric",
-              year: "numeric",
-            })
+          ? fmtDate(log.dateSubmitted)
           : undefined,
         status: "upcoming",
         taskList: log?.taskList,
@@ -158,14 +156,7 @@ function buildWeekEntries(worklogs: any[]): WeekEntry[] {
         entries.push({
           week: w,
           dueDate: dueDateStr,
-          submittedDate: new Date(log.dateSubmitted + "T00:00:00").toLocaleDateString(
-            "en-US",
-            {
-              month: "short",
-              day: "numeric",
-              year: "numeric",
-            },
-          ),
+          submittedDate: fmtDate(log.dateSubmitted),
           status: "submitted",
           isCurrent: true,
           taskList: log.taskList,
@@ -174,18 +165,14 @@ function buildWeekEntries(worklogs: any[]): WeekEntry[] {
         entries.push({ week: w, dueDate: dueDateStr, status: "current", isCurrent: true });
       }
     } else if (log) {
-      const submitted = new Date(log.dateSubmitted + "T00:00:00");
+      const submitted = new Date(log.dateSubmitted);
       const diffDays = Math.floor(
         (submitted.getTime() - dueDate.getTime()) / (1000 * 60 * 60 * 24),
       );
       entries.push({
         week: w,
         dueDate: dueDateStr,
-        submittedDate: new Date(log.dateSubmitted + "T00:00:00").toLocaleDateString("en-US", {
-          month: "short",
-          day: "numeric",
-          year: "numeric",
-        }),
+        submittedDate: fmtDate(log.dateSubmitted),
         status: diffDays > 0 ? "late" : "submitted",
         lateByDays: diffDays > 0 ? diffDays : undefined,
         taskList: log.taskList,

--- a/frontend/components/custom/screen/worklogform/WorklogForm.tsx
+++ b/frontend/components/custom/screen/worklogform/WorklogForm.tsx
@@ -61,6 +61,7 @@ import {
   pendingWorklogAtom,
 } from "@/components/custom/utils/context/state";
 import getWorklogDate from "../../utils/func/getDate";
+import { fmtDate, fmtDateTime } from "../../utils/func/formatDate";
 import { ChevronDown, ChevronRight, CalendarDays, Clock } from "lucide-react";
 
 function StatusBadge({ status }: { status: string }) {
@@ -107,7 +108,7 @@ function PreviousSubmission({
             </CardTitle>
             <p className="text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
               <Clock className="h-3 w-3" />
-              Submitted {submission.dateSubmitted}
+              Submitted {fmtDateTime(submission.dateSubmitted)}
             </p>
           </div>
           <CollapsibleTrigger asChild>
@@ -154,7 +155,7 @@ function PreviousSubmission({
                           Deadline
                         </p>
                         <p className="flex items-center gap-1">
-                          <CalendarDays className="h-3 w-3" /> {task.dueDate}
+                          <CalendarDays className="h-3 w-3" /> {fmtDate(task.dueDate)}
                         </p>
                       </div>
                     )}
@@ -196,9 +197,7 @@ export function WorkLogForm() {
   const [openTasks, setOpenTasks] = useState<Record<string, boolean>>({});
   const [worklogEdit, setWorklogEdit] = useAtom(worklogEditAtom);
 
-  const dateCreated = new Date().toLocaleDateString("en-CA", {
-    timeZone: "America/New_York",
-  });
+  const dateCreated = new Date().toISOString().replace("Z", "");
 
   const userInfo = useAtomValue(userAtom);
 
@@ -263,7 +262,7 @@ export function WorkLogForm() {
         collaborators: t.collaborators || [],
         assignedUser: t.assignedUser || "",
         status: t.status || ("not-started" as const),
-        dueDate: t.dueDate || "",
+        dueDate: t.dueDate ? t.dueDate.split("T")[0] : "",
         creationDate: t.creationDate || dateCreated,
         reflection: t.reflection || "",
       }));
@@ -282,7 +281,7 @@ export function WorkLogForm() {
           collaborators: t.collaborators || [],
           assignedUser: t.assignedUser || "",
           status: t.status || ("not-started" as const),
-          dueDate: t.dueDate || "",
+          dueDate: t.dueDate ? t.dueDate.split("T")[0] : "",
           creationDate: t.creationDate || dateCreated,
           reflection: t.reflection || "",
         }));
@@ -313,7 +312,7 @@ export function WorkLogForm() {
           collaborators: t.collaborators || [],
           assignedUser: t.assignedUser || "",
           status: t.status || ("not-started" as const),
-          dueDate: t.dueDate || "",
+          dueDate: t.dueDate ? t.dueDate.split("T")[0] : "",
           creationDate: t.creationDate || dateCreated,
           reflection: t.reflection || "",
         }));
@@ -347,6 +346,12 @@ export function WorkLogForm() {
     setOpenTasks((prev) => ({ ...prev, [id]: !prev[id] }));
   };
 
+  function toLocalDT(val: string | undefined | null): string {
+    if (!val) return "";
+    const s = /^\d{4}-\d{2}-\d{2}$/.test(val) ? `${val}T00:00:00` : val;
+    return s.replace("Z", "");
+  }
+
   function onSubmit(data: taskType) {
     if (!userInfo) return;
 
@@ -354,6 +359,8 @@ export function WorkLogForm() {
       ...t,
       assignedUser: userInfo.id,
       collaborators: t.collaborators.filter((c) => c !== ""),
+      dueDate: toLocalDT(t.dueDate),
+      creationDate: toLocalDT(t.creationDate),
     }));
 
     const obj: workLogPostType = {
@@ -375,7 +382,6 @@ export function WorkLogForm() {
     mutation.mutate(pendingWorklog);
   }
 
-
   return (
     <div className="p-4 sm:p-6 md:p-10">
       <h1 className="text-2xl sm:text-3xl md:text-4xl mb-1">
@@ -390,7 +396,11 @@ export function WorkLogForm() {
           end.setDate(end.getDate() + 6);
           const fmt = (d: Date) =>
             d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
-          return <span className="text-muted-foreground font-normal">({fmt(start)} - {fmt(end)})</span>;
+          return (
+            <span className="text-muted-foreground font-normal">
+              ({fmt(start)} - {fmt(end)})
+            </span>
+          );
         })()}
       </h1>
       <p className="text-sm text-muted-foreground mb-6 md:mb-8">
@@ -472,7 +482,10 @@ export function WorkLogForm() {
                               control={form.control}
                               render={({ field, fieldState }) => (
                                 <Field data-invalid={fieldState.invalid}>
-                                  <FieldLabel>Task Name <span className="text-red-500">*</span></FieldLabel>
+                                  <FieldLabel>
+                                    Task Name{" "}
+                                    <span className="text-red-500">*</span>
+                                  </FieldLabel>
                                   <Input
                                     {...field}
                                     placeholder="Task name"
@@ -490,7 +503,10 @@ export function WorkLogForm() {
                               control={form.control}
                               render={({ field, fieldState }) => (
                                 <Field data-invalid={fieldState.invalid}>
-                                  <FieldLabel>Main Goal <span className="text-red-500">*</span></FieldLabel>
+                                  <FieldLabel>
+                                    Main Goal{" "}
+                                    <span className="text-red-500">*</span>
+                                  </FieldLabel>
                                   <Input
                                     {...field}
                                     placeholder="Main goal"
@@ -539,10 +555,18 @@ export function WorkLogForm() {
                                     <div className="relative">
                                       <Input
                                         value={input}
-                                        onChange={(e) => setInput(e.target.value)}
+                                        onChange={(e) =>
+                                          setInput(e.target.value)
+                                        }
                                         onKeyDown={(e) => {
-                                          if (e.key === "Backspace" && input === "" && field.value.length > 0) {
-                                            field.onChange(field.value.slice(0, -1));
+                                          if (
+                                            e.key === "Backspace" &&
+                                            input === "" &&
+                                            field.value.length > 0
+                                          ) {
+                                            field.onChange(
+                                              field.value.slice(0, -1),
+                                            );
                                           }
                                           if (e.key === "Escape") {
                                             setInput("");
@@ -555,8 +579,16 @@ export function WorkLogForm() {
                                           {studentList
                                             .filter(
                                               (s: any) =>
-                                                (s.name.toLowerCase().includes(input.toLowerCase()) ||
-                                                 s.email.toLowerCase().includes(input.toLowerCase())) &&
+                                                (s.name
+                                                  .toLowerCase()
+                                                  .includes(
+                                                    input.toLowerCase(),
+                                                  ) ||
+                                                  s.email
+                                                    .toLowerCase()
+                                                    .includes(
+                                                      input.toLowerCase(),
+                                                    )) &&
                                                 !field.value.includes(s.name),
                                             )
                                             .map((s: any) => (
@@ -565,21 +597,38 @@ export function WorkLogForm() {
                                                 type="button"
                                                 className="w-full text-left px-3 py-2 hover:bg-gray-100 cursor-pointer"
                                                 onClick={() => {
-                                                  field.onChange([...field.value, s.name]);
+                                                  field.onChange([
+                                                    ...field.value,
+                                                    s.name,
+                                                  ]);
                                                   setInput("");
                                                 }}
                                               >
-                                                <p className="text-sm font-medium">{s.name}</p>
-                                                <p className="text-xs text-muted-foreground">{s.email}</p>
+                                                <p className="text-sm font-medium">
+                                                  {s.name}
+                                                </p>
+                                                <p className="text-xs text-muted-foreground">
+                                                  {s.email}
+                                                </p>
                                               </button>
                                             ))}
                                           {studentList.filter(
                                             (s: any) =>
-                                              (s.name.toLowerCase().includes(input.toLowerCase()) ||
-                                               s.email.toLowerCase().includes(input.toLowerCase())) &&
+                                              (s.name
+                                                .toLowerCase()
+                                                .includes(
+                                                  input.toLowerCase(),
+                                                ) ||
+                                                s.email
+                                                  .toLowerCase()
+                                                  .includes(
+                                                    input.toLowerCase(),
+                                                  )) &&
                                               !field.value.includes(s.name),
                                           ).length === 0 && (
-                                            <p className="px-3 py-2 text-sm text-muted-foreground">No matching students</p>
+                                            <p className="px-3 py-2 text-sm text-muted-foreground">
+                                              No matching students
+                                            </p>
                                           )}
                                         </div>
                                       )}
@@ -595,7 +644,10 @@ export function WorkLogForm() {
                                 control={form.control}
                                 render={({ field, fieldState }) => (
                                   <Field data-invalid={fieldState.invalid}>
-                                    <FieldLabel>Deadline <span className="text-red-500">*</span></FieldLabel>
+                                    <FieldLabel>
+                                      Deadline{" "}
+                                      <span className="text-red-500">*</span>
+                                    </FieldLabel>
                                     <Input
                                       {...field}
                                       type="date"
@@ -613,7 +665,10 @@ export function WorkLogForm() {
                                 control={form.control}
                                 render={({ field, fieldState }) => (
                                   <Field data-invalid={fieldState.invalid}>
-                                    <FieldLabel>Completion <span className="text-red-500">*</span></FieldLabel>
+                                    <FieldLabel>
+                                      Completion{" "}
+                                      <span className="text-red-500">*</span>
+                                    </FieldLabel>
                                     <Select
                                       onValueChange={field.onChange}
                                       value={field.value}
@@ -646,7 +701,10 @@ export function WorkLogForm() {
                               control={form.control}
                               render={({ field, fieldState }) => (
                                 <Field data-invalid={fieldState.invalid}>
-                                  <FieldLabel>Reflection <span className="text-red-500">*</span></FieldLabel>
+                                  <FieldLabel>
+                                    Reflection{" "}
+                                    <span className="text-red-500">*</span>
+                                  </FieldLabel>
                                   <InputGroup>
                                     <InputGroupTextarea
                                       {...field}
@@ -696,7 +754,8 @@ export function WorkLogForm() {
       </Button>
 
       <p className="text-xs text-muted-foreground mt-3 text-center">
-        Once submitted, this log cannot be edited. You will need to create a new submission to make changes.
+        Once submitted, this log cannot be edited. You will need to create a new
+        submission to make changes.
       </p>
 
       <AlertDialog open={showConfirm} onOpenChange={setShowConfirm}>
@@ -706,7 +765,8 @@ export function WorkLogForm() {
               Are you sure you want to submit your log?
             </AlertDialogTitle>
             <AlertDialogDescription className="text-base text-muted-foreground">
-              Once submitted, this log cannot be edited. You will need to create a new submission to make changes.
+              Once submitted, this log cannot be edited. You will need to create
+              a new submission to make changes.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <div className="flex flex-col gap-3 mt-4">

--- a/frontend/components/custom/utils/func/formatDate.ts
+++ b/frontend/components/custom/utils/func/formatDate.ts
@@ -1,0 +1,35 @@
+const TZ = "America/New_York";
+
+/**
+ * Format a date value (ISO string or Date) as a short date in EST/EDT.
+ * e.g. "Apr 14, 2026"
+ */
+export function fmtDate(val: string | Date | null | undefined): string {
+  if (!val) return "—";
+  const d = typeof val === "string" ? new Date(val) : val;
+  if (isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString("en-US", {
+    timeZone: TZ,
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+/**
+ * Format a date value with time in EST/EDT.
+ * e.g. "Apr 14, 2026, 8:47 PM"
+ */
+export function fmtDateTime(val: string | Date | null | undefined): string {
+  if (!val) return "—";
+  const d = typeof val === "string" ? new Date(val) : val;
+  if (isNaN(d.getTime())) return "—";
+  return d.toLocaleString("en-US", {
+    timeZone: TZ,
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}


### PR DESCRIPTION
## Description
As of now, we have been using Date to represent some fields. This PR introduces UTC formatted timezone field to utilize as standard across the application. Every field that have date will be stored in this format (e.g. 2026-04-14T00:38:56.530) 

> Note: This PR introduces a breaking change due to inconsistency between string vs Mongo Date.

### Backend
- Updates from `LocalDate` to `LocalDateTime`
- Add JSONWriter to send simple date instead of MongoDB formatted json date object

<img width="485" height="440" alt="Screenshot 2026-04-13 at 9 28 14 PM" src="https://github.com/user-attachments/assets/41095af0-bfc5-47b0-8e41-070fe4b6b434" />

### Frontend
- Introduce formatDate.js helper functions to display UTC formatted time zone into EST/EDT time.
- Updates all locations that utilize dates with aforementioned functions
- add function stripZ as LocalDateTime cannot process UTC trailing Z

<img width="395" height="117" alt="Screenshot 2026-04-13 at 9 22 27 PM" src="https://github.com/user-attachments/assets/a5aaee5e-b27c-47c3-9b55-f3534d6fbe30" />
<img width="1264" height="773" alt="Screenshot 2026-04-13 at 9 23 42 PM" src="https://github.com/user-attachments/assets/4c581eb3-2a34-4d9c-a825-a6fec1000620" />
<img width="1241" height="766" alt="Screenshot 2026-04-13 at 9 24 01 PM" src="https://github.com/user-attachments/assets/80c5e49c-3f3d-495b-8324-57c6af889e71" />

Closes #57 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (breaking 
- [ ] Documentation update
- [ ] Other: