### PR TITLE
fixed worklog DateTime parse error

### DIFF
--- a/backend/worklog/src/main/java/worklog/application/WorklogEntry.java
+++ b/backend/worklog/src/main/java/worklog/application/WorklogEntry.java
@@ -14,7 +14,7 @@ public class WorklogEntry {
     @NotEmpty(message = "Worklog must have an author!")
     private String authorName;
 
-    @NotEmpty(message = "Worklog must have all the teams associated!")
+    // @NotEmpty(message = "Worklog must have all the teams associated!")
     private List<String> teamNames;
     
     @NotEmpty(message = "Worklog must have week name!")
@@ -26,7 +26,7 @@ public class WorklogEntry {
     @NotNull(message = "Date submitted required")
     private LocalDateTime dateSubmitted;
 
-    @NotNull(message = "Deadline required")
+    // @NotNull(message = "Deadline required")
     private LocalDateTime deadline;
     private boolean reviewed = false;
 

--- a/backend/worklog/src/main/java/worklog/application/WorklogRepository.java
+++ b/backend/worklog/src/main/java/worklog/application/WorklogRepository.java
@@ -91,9 +91,10 @@ public class WorklogRepository {
         newDoc.put("worklogName", entry.getWorklogName());
         newDoc.put("taskList", formatTask(entry.getTaskList()));
         newDoc.put("teamNames", entry.getTeamNames());
-        newDoc.put("deadline", entry.getDeadline());
         newDoc.put("reviewed", false);
         newDoc.put("isDraft", false);
+
+        if (entry.getDeadline() != null) newDoc.put("deadline", entry.getDeadline());
 
         collection.insertOne(newDoc);
 
@@ -261,7 +262,7 @@ public class WorklogRepository {
         newDoc.put("taskList", formatTask(updatedEntry.getTaskList()));
         newDoc.put("worklogName", updatedEntry.getWorklogName());
         newDoc.put("teamNames", updatedEntry.getTeamNames());
-        newDoc.put("deadline", updatedEntry.getDeadline());
+        if (updatedEntry.getDeadline() != null) newDoc.put("deadline", updatedEntry.getDeadline());
 
         if (isInstructor) {
             newDoc.put("reviewed", updatedEntry.isReviewed());

--- a/backend/worklog/src/main/java/worklog/application/WorklogService.java
+++ b/backend/worklog/src/main/java/worklog/application/WorklogService.java
@@ -1,6 +1,7 @@
 package worklog.application;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -18,6 +19,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
@@ -64,7 +66,7 @@ public class WorklogService {
     @Path("/author/{authorName}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get worklog by author name in the database.")
-    public Response getWorklogByAuthorName(@jakarta.ws.rs.PathParam("authorName") String authorName) {
+    public Response getWorklogByAuthorName(@PathParam("authorName") String authorName) {
         logger.log(Level.INFO, "GET: getWorklogByAuthorName()");
         return repo.getByAuthorName(authorName);
     }
@@ -73,7 +75,7 @@ public class WorklogService {
     @Path("/teams/{teamNames}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get worklog by team names in the database.")
-    public Response getWorklogByTeamNames(@jakarta.ws.rs.PathParam("teamNames") List<String> teamNames) {
+    public Response getWorklogByTeamNames(@PathParam("teamNames") List<String> teamNames) {
         logger.log(Level.INFO, "GET: getWorklogByTeamNames()");
         return repo.getByTeamNames(teamNames);
     }
@@ -82,18 +84,20 @@ public class WorklogService {
     @Path("/deadline/{deadline}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get worklog by deadline in the database.")
-    public Response getWorklogByDeadline(@jakarta.ws.rs.PathParam("deadline") LocalDateTime deadline) {
+    public Response getWorklogByDeadline(@PathParam("deadline") String deadline) {
         logger.log(Level.INFO, "GET: getWorklogByDeadline()");
-        return repo.getByDeadline(deadline);
+        LocalDateTime deadDateTime = LocalDateTime.parse(deadline, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        return repo.getByDateSubmitted(deadDateTime);
     }
 
     @GET
     @Path("/dateSubmitted/{dateSubmitted}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get worklog by date submitted in the database.")
-    public Response getWorklogByDateSubmitted(@jakarta.ws.rs.PathParam("dateSubmitted") LocalDateTime dateSubmitted) {
+    public Response getWorklogByDateSubmitted(@PathParam("dateSubmitted") String dateSubmitted) {
         logger.log(Level.INFO, "GET: getWorklogByDateSubmitted()");
-        return repo.getByDateSubmitted(dateSubmitted);
+        LocalDateTime subDateTime = LocalDateTime.parse(dateSubmitted, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        return repo.getByDateSubmitted(subDateTime);
     }
 
     @GET
@@ -129,7 +133,7 @@ public class WorklogService {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Update worklog draft by mongo ID in the database.")
-    public Response updateWorklog(@jakarta.ws.rs.PathParam("id") String id, @Valid WorklogEntry updatedEntry) {
+    public Response updateWorklog(@PathParam("id") String id, @Valid WorklogEntry updatedEntry) {
         boolean isInstructor = securityContext.isUserInRole("instructor");
         return repo.updateWorklog(id, updatedEntry, isInstructor);
     }
@@ -158,7 +162,7 @@ public class WorklogService {
     @DELETE
     @Path("/id/{id}")
     @Operation(summary = "Deletes by mongo ID")
-    public Response deleteWorklog(@jakarta.ws.rs.PathParam("id") String id) {
+    public Response deleteWorklog(@PathParam("id") String id) {
         logger.log(Level.INFO, "DELETE: deleteWorklog()");
         return repo.deleteWorklog(id);
     }


### PR DESCRIPTION
## Description
This PR fixes an error from the worklog date parser, converting input from a LocalDateTime to a string, as it can not automatically convert from LocalDateTime to JSON or vice versa 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Other: